### PR TITLE
Step 6: Implement caching with Redis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,7 @@ WORKDIR /app
 COPY build/libs/taskmanager-0.0.1-SNAPSHOT.jar app.jar
 
 # Run the application
-ENTRYPOINT ["java", "-jar", "app.jar", "--spring.config.name=application-docker"]
+ENTRYPOINT ["java", "-jar", "app.jar", "--spring.profiles.active=docker"]
+
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,8 @@ dependencies {
 	implementation 'org.flywaydb:flyway-core:9.22.3'
 	testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
 	testImplementation 'org.mockito:mockito-core:5.12.0'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,18 @@ services:
       interval: 5s
       retries: 5
 
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-server", "--version"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 10s
+
+
   app:
     build: .
     container_name: taskmanager-app
@@ -24,6 +36,8 @@ services:
       - "8080:8080"
     depends_on:
       db:
+        condition: service_healthy
+      redis:
         condition: service_healthy
     environment:
       SPRING_PROFILES_ACTIVE: docker

--- a/src/main/java/com/example/taskmanager/TaskmanagerApplication.java
+++ b/src/main/java/com/example/taskmanager/TaskmanagerApplication.java
@@ -2,8 +2,10 @@ package com.example.taskmanager;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class TaskmanagerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/taskmanager/config/RedisConfig.java
+++ b/src/main/java/com/example/taskmanager/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package com.example.taskmanager.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory("redis", 6379);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<byte[], byte[]> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        return template;
+    }
+}

--- a/src/main/java/com/example/taskmanager/model/Task.java
+++ b/src/main/java/com/example/taskmanager/model/Task.java
@@ -4,13 +4,16 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDateTime;
+import java.io.Serializable;
 
 @Entity
 @Data
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
-public class Task {
+public class Task implements Serializable {
+
+    private static final long serialVersionUID = 1L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/resources/application-docker.properties
+++ b/src/main/resources/application-docker.properties
@@ -10,3 +10,12 @@ spring.jpa.show-sql=true
 spring.flyway.enabled=true
 spring.flyway.baseline-on-migrate=true
 
+spring.cache.type=redis
+spring.redis.host=redis
+spring.redis.port=6379
+spring.cache.redis.time-to-live=600000ms
+
+logging.level.org.springframework.cache=DEBUG
+logging.level.org.springframework.data.redis.cache=DEBUG
+logging.level.org.springframework.data.redis=DEBUG
+spring.data.redis.repositories.enabled=false


### PR DESCRIPTION
Implemented caching using Redis and Spring Cache. Task retrieval by user ID is now cached to reduce load on the database. If the cache does not contain the data, it falls back to fetching from the database. A time-to-live (TTL) is set for cached entries to ensure data freshness. 

The caching functionality was verified via Postman: two consecutive requests to retrieve tasks by user ID were made — the first triggered an SQL query, while the second returned data from the cache. Additionally, Redis created the key tasks::1, confirming the caching behavior.
![изображение](https://github.com/user-attachments/assets/715bfb1b-91ed-4206-837e-d57d4e38b1d5)
