### PR TITLE
Step 7: added RabbitMQ integration and task notification publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 	testImplementation 'org.mockito:mockito-core:5.12.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'org.springframework.boot:spring-boot-starter-amqp'
+
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
       retries: 5
       start_period: 10s
 
-
   app:
     build: .
     container_name: taskmanager-app
@@ -45,6 +44,17 @@ services:
       SPRING_DATASOURCE_USERNAME: user
       SPRING_DATASOURCE_PASSWORD: password
       SPRING_JPA_HIBERNATE_DDL_AUTO: none
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: taskmanager-rabbitmq
+    ports:
+      - "5672:5672"      # порт для приложений
+      - "15672:15672"    # порт для веб-интерфейса
+    environment:
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
+
 
 
 volumes:

--- a/src/main/java/com/example/taskmanager/config/RabbitMQConfig.java
+++ b/src/main/java/com/example/taskmanager/config/RabbitMQConfig.java
@@ -1,0 +1,43 @@
+package com.example.taskmanager.config;
+
+import org.springframework.amqp.core.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String QUEUE = "notificationQueue";
+    public static final String EXCHANGE = "notificationExchange";
+    public static final String ROUTING_KEY = "notificationRoutingKey";
+
+    @Bean
+    public Queue queue() {
+        return new Queue(QUEUE);
+    }
+
+    @Bean
+    public TopicExchange exchange() {
+        return new TopicExchange(EXCHANGE);
+    }
+
+    @Bean
+    public Binding binding(Queue queue, TopicExchange exchange) {
+        return BindingBuilder.bind(queue).to(exchange).with(ROUTING_KEY);
+    }
+
+    @Bean
+    public Jackson2JsonMessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(jsonMessageConverter());
+        return template;
+    }
+}

--- a/src/main/java/com/example/taskmanager/dto/NotificationMessage.java
+++ b/src/main/java/com/example/taskmanager/dto/NotificationMessage.java
@@ -1,0 +1,15 @@
+package com.example.taskmanager.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class NotificationMessage {
+    private Long userId;
+    private String message;
+}

--- a/src/main/java/com/example/taskmanager/messaging/MessageListener.java
+++ b/src/main/java/com/example/taskmanager/messaging/MessageListener.java
@@ -1,0 +1,32 @@
+package com.example.taskmanager.messaging;
+
+import com.example.taskmanager.dto.NotificationMessage;
+import com.example.taskmanager.service.NotificationService;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+import com.example.taskmanager.model.Notification;
+
+
+@Component
+public class MessageListener {
+
+    private final NotificationService notificationService;
+
+    public MessageListener(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
+
+    @RabbitListener(queues = "#{T(com.example.taskmanager.config.RabbitMQConfig).QUEUE}")
+    public void receiveMessage(NotificationMessage message) {
+        notificationService.save(new Notification(
+                null,
+                message.getUserId(),
+                message.getMessage(),
+                false
+        ));
+    }
+
+
+
+
+}

--- a/src/main/java/com/example/taskmanager/messaging/MessagePublisher.java
+++ b/src/main/java/com/example/taskmanager/messaging/MessagePublisher.java
@@ -1,0 +1,24 @@
+package com.example.taskmanager.messaging;
+
+import com.example.taskmanager.config.RabbitMQConfig;
+import com.example.taskmanager.dto.NotificationMessage;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MessagePublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public MessagePublisher(RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    public void sendNotification(NotificationMessage message) {
+        rabbitTemplate.convertAndSend(
+                RabbitMQConfig.EXCHANGE,
+                RabbitMQConfig.ROUTING_KEY,
+                message
+        );
+    }
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -1,0 +1,6 @@
+spring:
+  rabbitmq:
+    host: rabbitmq
+    port: 5672
+    username: guest
+    password: guest


### PR DESCRIPTION
In Step 7, I implemented a messaging system using RabbitMQ. I configured RabbitMQ as the message broker and set it up to publish a message whenever a new task is created. The NotificationService was refactored to receive updates exclusively from the message broker, ensuring decoupling from the task creation logic. I also created a message listener to handle incoming messages asynchronously and persist notifications.

Screenshot below shows notificationExchange activity in the RabbitMQ Management UI, confirming that messages are successfully being published and routed.
![3a3f80e9-98a2-40cc-a377-c8c809c6ca04](https://github.com/user-attachments/assets/90fdffe2-0c04-4f85-a5ba-1d587c7a7001)
